### PR TITLE
ipfs-cap2pfs: Remove trailing comma from blob JSON

### DIFF
--- a/papers/ipfs-cap2pfs/ipfs-cap2pfs.tex
+++ b/papers/ipfs-cap2pfs/ipfs-cap2pfs.tex
@@ -740,7 +740,7 @@ represents a file. IPFS Blocks are like Git blobs or filesystem data blocks. The
 
 \begin{verbatim}
 {
-  "data": "some data here",
+  "data": "some data here"
   // blobs have no links
 }
 \end{verbatim}


### PR DESCRIPTION
It's not valid JSON to have a comma as the last token in an object or
list.
