### PR TITLE
Fix type

### DIFF
--- a/papers/ipfs-cap2pfs/ipfs-cap2pfs.tex
+++ b/papers/ipfs-cap2pfs/ipfs-cap2pfs.tex
@@ -342,7 +342,7 @@ The differing strategies that BitSwap peers might employ have wildly different e
 
 The exploration of the space of such strategies is future work.
 One choice of function that works in practice is a sigmoid, scaled by a
-\textit{debt retio}:
+\textit{debt ratio}:
 
 Let the \textit{debt ratio} $ r $ between a node and its peer be:
   \[ r = \dfrac{\texttt{bytes\_sent}}{\texttt{bytes\_recv} + 1} \]


### PR DESCRIPTION
`ratio` is misspelled as `retio`.