### PR TITLE
Add hyperlinks to contributor document

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -5,7 +5,7 @@ There are many ways to contribute to IPFS development. This document will flesh 
 
 ### Help with the design
 
-If you find an error or have a suggestion for the overall design of IPFS, please submit an Issue.
+If you find an error or have a suggestion for the overall design of IPFS, please submit an [Issue](https://github.com/ipfs/ipfs/issues/new).
 
 ### Help with the implementations
 
@@ -17,4 +17,4 @@ Please tweet, email, tell everyone about this. IPFS will succeed only if many pe
 
 ### Help in other ways
 
-Email me directly if you'd like to help in other ways.
+[Email me directly](mailto:juan@benet.ai?subject=Contributing to IPFS) if you'd like to help in other ways.


### PR DESCRIPTION
@jbenet Hello, I added a couple of hyperlinks in CONTRIBUTE.md so that:

1. Potential contributors could open a new issue in one click.
2. Be able to email you without having to find your email address.

Hope you have a nice weekend.