### PR TITLE
Project Directory cleanup

### DIFF
--- a/project-directory.md
+++ b/project-directory.md
@@ -32,28 +32,28 @@ These are all the repos found in the IPFS Github organization. If you still can'
 
 ## Discussions
 
+* [apps](https://github.com/ipfs/apps)  
+    Coordinating writing apps on top of ipfs, and their concerns.
+
+* [archives](https://github.com/ipfs/archives)  
+    Repo to coordinate archival efforts with IPFS.
+
 * [faq](https://github.com/ipfs/faq)  
     Frequently Asked Questions, and answers. Look at the issues.
 
 * [notes](https://github.com/ipfs/notes)  
     Various relevant notes and discussions (that do not fit elsewhere).
 
-* [archives](https://github.com/ipfs/archives)  
-    Repo to coordinate archival efforts with IPFS.
-
-* [apps](https://github.com/ipfs/apps)  
-    Coordinating writing apps on top of ipfs, and their concerns. 
-
 ### Specification Discussions
-
-* [blockchain-data](https://github.com/ipfs/blockchain-data)  
-    Using IPFS for storing data for Blockchain apps.
 
 * [archive-format](https://github.com/ipfs/archive-format)  
     A discussion repository for the archive format spec.
 
 * [bitswap-ml](https://github.com/ipfs/bitswap-ml)  
     bitswap + ml.
+
+* [blockchain-data](https://github.com/ipfs/blockchain-data)  
+    Using IPFS for storing data for Blockchain apps.
 
 ## Implementations
 
@@ -64,25 +64,25 @@ These are all the repos found in the IPFS Github organization. If you still can'
 
 ### In Development
 
+* [go-ipld](https://github.com/ipfs/go-ipld)  
+    This is the Go implementation of the IPLD spec.
+
 * [js-ipfs](https://github.com/ipfs/js-ipfs)  
     An IPFS implementation in Node.js.
 
 * [py-ipfs](https://github.com/ipfs/py-ipfs)  
     Python implementation of IPFS.
 
-* [go-ipld](https://github.com/ipfs/go-ipld)  
-    This is the Go implementation of the IPLD spec.
-
 ### APIs
-
-* [js-ipfs-api](https://github.com/ipfs/js-ipfs-api)  
-    A node client library for the IPFS API.
 
 * [go-ipfs-api](https://github.com/ipfs/go-ipfs-api)  
     An unofficial go interface to IPFS's http API.
 
 * [java-ipfs-api](https://github.com/ipfs/java-ipfs-api)  
     A Java implementation of the HTTP IPFS API.
+
+* [js-ipfs-api](https://github.com/ipfs/js-ipfs-api)  
+    A node client library for the IPFS API.
 
 * [python-ipfs-api](https://github.com/ipfs/python-ipfs-api)  
     A python client library for the IPFS API.
@@ -95,17 +95,17 @@ These are all the repos found in the IPFS Github organization. If you still can'
 * [astralboot](https://github.com/ipfs/astralboot)  
     A low level boot server that deploys directly out of IPFS.
 
-* [webui](https://github.com/ipfs/webui)  
-    The IPFS webui accessible from the api gateway typically at port 5001.
-
-* [starlog](https://github.com/ipfs/starlog)  
-    Logging the development of an interplanetary filesystem. This will evenutlaly be a way of making blog posts with IPFS.
-
 * [electron-app](https://github.com/ipfs/electron-app)  
     Electron Shell based IPFS app.
 
 * [ipfs-web-app](https://github.com/ipfs/ipfs-web-app)  
     IPFS web app interface.
+
+* [starlog](https://github.com/ipfs/starlog)  
+    Logging the development of an interplanetary filesystem. This will evenutlaly be a way of making blog posts with IPFS.
+
+* [webui](https://github.com/ipfs/webui)  
+    The IPFS webui accessible from the api gateway typically at port 5001.
 
 ## Demos and Examples
 
@@ -116,46 +116,35 @@ These are all the repos found in the IPFS Github organization. If you still can'
     Examples on how to use go-ipfs.
 
 ## Community Resources
-* [community](https://github.com/ipfs/community)  
-    General discussion and documentation on community practices.
-
-* [support](https://github.com/ipfs/support)  
-    For questions on how to get IPFS up and running smoothly.
-
-* [infrastructure](https://github.com/ipfs/infrastructure)  
-    Tools and systems for the community.
-
-* [pm](https://github.com/ipfs/pm)  
-    General project management.
-
-* [website](https://github.com/ipfs/website)  
-    The source to the IPFS community website at http://ipfs.io.
-
-* [logo](https://github.com/ipfs/logo)  
-    The logo for IPFS.
-
-* [blog](https://github.com/ipfs/blog)  
-    IPFS Blog.
 
 * [awesome-ipfs](https://github.com/ipfs/awesome-ipfs)  
     Useful resources for using IPFS and building things on top of it.
 
+* [blog](https://github.com/ipfs/blog)  
+    IPFS Blog.
+
+* [community](https://github.com/ipfs/community)  
+    General discussion and documentation on community practices.
+
+* [infrastructure](https://github.com/ipfs/infrastructure)  
+    Tools and systems for the community.
+
+* [logo](https://github.com/ipfs/logo)  
+    The logo for IPFS.
+
 * [meetup-lisbon](https://github.com/ipfs/meetup-lisbon)  
     The IPFS meetup in Lisbon.
 
+* [pm](https://github.com/ipfs/pm)  
+    General project management.
+
+* [support](https://github.com/ipfs/support)  
+    For questions on how to get IPFS up and running smoothly.
+
+* [website](https://github.com/ipfs/website)  
+    The source to the IPFS community website at http://ipfs.io.
+
 ## Tools
-
-* [dnslink-deploy](https://github.com/ipfs/dnslink-deploy)  
-    Automatically set DNS records on Digital Ocean.
-
-* [js-ipfsd-ctl](https://github.com/ipfs/js-ipfsd-ctl)  
-    Control an IPFS daemon (WIP).
-
-* [npm-go-ipfs](https://github.com/ipfs/npm-go-ipfs)  
-    Install go-ipfs from npm.
-
-* [fs-repo-migrations](https://github.com/ipfs/fs-repo-migrations)  
-    These are migrations for the filesystem repository of IPFS clients.
 
 * [api](https://github.com/ipfs/api)  
     The APIs IPFS implementations must conform to, with planned test suites to check conformity.
@@ -163,43 +152,61 @@ These are all the repos found in the IPFS Github organization. If you still can'
 * [dataviz](https://github.com/ipfs/dataviz)  
     IPFS data visualizations.
 
+* [dir-index-html](https://github.com/ipfs/dir-index-html)  
+    Directory listing html.
+
+* [distributions](https://github.com/ipfs/distributions)  
+    Script to build the /install html page.
+
+* [dnslink-deploy](https://github.com/ipfs/dnslink-deploy)  
+    Automatically set DNS records on Digital Ocean.
+
+* [fs-repo-migrations](https://github.com/ipfs/fs-repo-migrations)  
+    These are migrations for the filesystem repository of IPFS clients.
+
 * [fs-stress-test](https://github.com/ipfs/fs-stress-test)  
     This repo will stress test IPFS filesystem capabilities.
 
 * [go-blocks](https://github.com/ipfs/go-blocks)  
     Go-blocks - IPFS blocks.
 
-* [go-iprs](https://github.com/ipfs/go-iprs)  
-    Go-ipfs records.
-
-* [dir-index-html](https://github.com/ipfs/dir-index-html)  
-    Directory listing html.
-
-* [ipfs-node-defaults](https://github.com/ipfs/ipfs-node-defaults)  
-    Sane defaults for IPFS node configurations.
-
-* [distributions](https://github.com/ipfs/distributions)  
-    Script to build the /install html page.
-
 * [go-commands](https://github.com/ipfs/go-commands)  
     Go commands. WIP.
 
-* [install-go-ipfs](https://github.com/ipfs/install-go-ipfs)  
-    Install go-ipfs shell script.
+* [go-iprs](https://github.com/ipfs/go-iprs)  
+    Go-ipfs records.
 
 * [go-log](https://github.com/ipfs/go-log)  
     A logging library used by go-ipfs.
 
+* [install-go-ipfs](https://github.com/ipfs/install-go-ipfs)  
+    Install go-ipfs shell script.
+
+* [ipfs-node-defaults](https://github.com/ipfs/ipfs-node-defaults)  
+    Sane defaults for IPFS node configurations.
+
+* [js-ipfsd-ctl](https://github.com/ipfs/js-ipfsd-ctl)  
+    Control an IPFS daemon (WIP).
+
 * [js-ipfs-path](https://github.com/ipfs/js-ipfs-path)  
     Javascript helper functions for IPFS path handling
 
+* [npm-go-ipfs](https://github.com/ipfs/npm-go-ipfs)  
+    Install go-ipfs from npm.
+
 ## Random modules
 
-* [ipfs-hubot](https://github.com/ipfs/ipfs-hubot)  
-    hubot for IPFS (WIP!!).
+* [gateway-dmca-denylist](https://github.com/ipfs/gateway-dmca-denylist)  
+    API for IPFS keys to which access should be denied.
+
+* [ipfs.js](https://github.com/ipfs/ipfs.js)  
+    A squatted repo, for future client side IPFS js.
 
 * [ipfs-blob-store](https://github.com/ipfs/ipfs-blob-store)  
     A place to buy blobs.
+
+* [ipfs-hubot](https://github.com/ipfs/ipfs-hubot)  
+    hubot for IPFS (WIP!!).
 
 * [refs](https://github.com/ipfs/refs)
     Tool for building and publishing the DAG at https://ipfs.io/refs.
@@ -210,6 +217,4 @@ These are all the repos found in the IPFS Github organization. If you still can'
 * [refs-solarnet-storage](https://github.com/ipfs/refs-solarnet-storage)
     Source for the `refs` tool. Content archived on the storage hosts.
 
-* [ipfs.js](https://github.com/ipfs/ipfs.js)  
-    A squatted repo, for future client side IPFS js.
 

--- a/project-directory.md
+++ b/project-directory.md
@@ -82,7 +82,7 @@ These are all the repos found in the IPFS Github organization. If you still can'
     A Java implementation of the HTTP IPFS API.
 
 * [js-ipfs-api](https://github.com/ipfs/js-ipfs-api)  
-    A JavaScript client library for the IPFS API.
+    A client library for the IPFS HTTP API, implemented in JavaScript.
 
 * [python-ipfs-api](https://github.com/ipfs/python-ipfs-api)  
     A python client library for the IPFS API.
@@ -128,6 +128,9 @@ These are all the repos found in the IPFS Github organization. If you still can'
 
 * [infrastructure](https://github.com/ipfs/infrastructure)  
     Tools and systems for the community.
+
+* [ipfs-readme-standard](https://github.com/ipfs/ipfs-readme-standard)  
+    Standardize all IPFS Readme.md's and other markdown files
 
 * [logo](https://github.com/ipfs/logo)  
     The logo for IPFS.
@@ -176,14 +179,23 @@ These are all the repos found in the IPFS Github organization. If you still can'
 * [go-iprs](https://github.com/ipfs/go-iprs)  
     Go-ipfs records.
 
+* [go-libp2p](https://github.com/ipfs/go-libp2p)  
+    libp2p is a networking stack and library modularized out of The IPFS Project, and bundled separately for other tools to use.
+
 * [go-log](https://github.com/ipfs/go-log)  
     A logging library used by go-ipfs.
 
 * [install-go-ipfs](https://github.com/ipfs/install-go-ipfs)  
     Install go-ipfs shell script.
 
+* [ipfs-geoip](https://github.com/ipfs/ipfs-geoip)  
+    Geoip over ipfs
+
 * [ipfs-js-defaults](https://github.com/ipfs/ipfs-js-defaults)  
     Sane defaults for IPFS node configurations.
+
+* [ipfs-update](https://github.com/ipfs/ipfs-update)  
+    An updater tool for ipfs
 
 * [js-ipfsd-ctl](https://github.com/ipfs/js-ipfsd-ctl)  
     Control an IPFS daemon (WIP).
@@ -196,9 +208,6 @@ These are all the repos found in the IPFS Github organization. If you still can'
 
 ## Random modules
 
-* [gateway-dmca-denylist](https://github.com/ipfs/gateway-dmca-denylist)  
-    API for IPFS keys to which access should be denied.
-
 * [ipfs.js](https://github.com/ipfs/ipfs.js)  
     A squatted repo, for future client side IPFS js.
 
@@ -208,13 +217,15 @@ These are all the repos found in the IPFS Github organization. If you still can'
 * [ipfs-hubot](https://github.com/ipfs/ipfs-hubot)  
     hubot for IPFS (WIP!!).
 
-* [refs](https://github.com/ipfs/refs)
-    Tool for building and publishing the DAG at https://ipfs.io/refs.
+* [ipfs-npm](https://github.com/ipfs/ipfs-npm)  
+    npm on IPFS
 
-* [refs-denylists-dmca](https://github.com/ipfs/refs-denylists-dmca)
-    Source for the `refs` tool. DMCA notices served for the ipfs.io gateway.
+* [refs](https://github.com/ipfs/refs)  
+    DMCA notices, and tools for publishing them https://ipfs.io/refs/lists/denylists/dmca
+
+* [refs-denylists-dmca](https://github.com/ipfs/refs-denylists-dmca)  
+    DMCA takedown notices
 
 * [refs-solarnet-storage](https://github.com/ipfs/refs-solarnet-storage)
     Source for the `refs` tool. Content archived on the storage hosts.
-
 

--- a/project-directory.md
+++ b/project-directory.md
@@ -14,6 +14,7 @@ Note: The repository descriptions (ought to) originate from the GitHub repositor
     - [Active](#active)
     - [In Development](#in-development)
     - [APIs](#apis)
+    - [Specs](#specs)
 - [Applications](#applications)
 - [Demos and Examples](#demos-and-examples)
 - [Community Resources](#community-resources)
@@ -66,9 +67,6 @@ Note: The repository descriptions (ought to) originate from the GitHub repositor
 
 ### In Development
 
-* [go-ipld](https://github.com/ipfs/go-ipld)  
-    This is the Go implementation of the IPLD spec.
-
 * [js-ipfs](https://github.com/ipfs/js-ipfs)  
     An IPFS implementation in Node.js.
 
@@ -94,6 +92,14 @@ Note: The repository descriptions (ought to) originate from the GitHub repositor
 
 * [swift-ipfs-api](https://github.com/ipfs/swift-ipfs-api)  
     A Swift client library for the IPFS API.
+
+### Specs
+
+* [go-ipld](https://github.com/ipfs/go-ipld)  
+    This is the Go implementation of the IPLD spec.
+
+* [js-ipfs-repo](https://github.com/ipfs/js-ipfs-repo)  
+    Implementation of the IPFS repo spec (https://github.com/ipfs/specs/tree/master/repo) in JavaScript
 
 ## Applications
 

--- a/project-directory.md
+++ b/project-directory.md
@@ -181,6 +181,9 @@ Note: The repository descriptions (ought to) originate from the GitHub repositor
 * [go-commands](https://github.com/ipfs/go-commands)  
     Go commands. WIP.
 
+* [go-ipfs-util](https://github.com/ipfs/go-ipfs-util)  
+    Common utilities used by go-ipfs and other related go packages
+
 * [go-iprs](https://github.com/ipfs/go-iprs)  
     Go-ipfs records.
 

--- a/project-directory.md
+++ b/project-directory.md
@@ -175,6 +175,9 @@ Note: The repository descriptions (ought to) originate from the GitHub repositor
 * [dnslink-deploy](https://github.com/ipfs/dnslink-deploy)  
     Automatically set DNS records on Digital Ocean.
 
+* [file-browser](https://github.com/ipfs/file-browser)
+    generic-ipfs-file-browser-ui-thing
+
 * [fs-repo-migrations](https://github.com/ipfs/fs-repo-migrations)  
     These are migrations for the filesystem repository of IPFS clients.
 

--- a/project-directory.md
+++ b/project-directory.md
@@ -190,6 +190,9 @@ These are all the repos found in the IPFS Github organization. If you still can'
 * [go-log](https://github.com/ipfs/go-log)  
     A logging library used by go-ipfs.
 
+* [js-ipfs-path](https://github.com/ipfs/js-ipfs-path)  
+    Javascript helper functions for IPFS path handling
+
 ## Random modules
 
 * [ipfs-hubot](https://github.com/ipfs/ipfs-hubot)  

--- a/project-directory.md
+++ b/project-directory.md
@@ -90,6 +90,9 @@ These are all the repos found in the IPFS Github organization. If you still can'
 * [scala-ipfs-api](https://github.com/ipfs/scala-ipfs-api)  
     A wrapper of the IPFS Client HTTP-API  for Scala.
 
+* [swift-ipfs-api](https://github.com/ipfs/swift-ipfs-api)  
+    A Swift client library for the IPFS API.
+
 ## Applications
 
 * [astralboot](https://github.com/ipfs/astralboot)  

--- a/project-directory.md
+++ b/project-directory.md
@@ -82,7 +82,7 @@ These are all the repos found in the IPFS Github organization. If you still can'
     A Java implementation of the HTTP IPFS API.
 
 * [js-ipfs-api](https://github.com/ipfs/js-ipfs-api)  
-    A node client library for the IPFS API.
+    A JavaScript client library for the IPFS API.
 
 * [python-ipfs-api](https://github.com/ipfs/python-ipfs-api)  
     A python client library for the IPFS API.
@@ -95,14 +95,14 @@ These are all the repos found in the IPFS Github organization. If you still can'
 * [astralboot](https://github.com/ipfs/astralboot)  
     A low level boot server that deploys directly out of IPFS.
 
-* [electron-app](https://github.com/ipfs/electron-app)  
-    Electron Shell based IPFS app.
-
 * [ipfs-web-app](https://github.com/ipfs/ipfs-web-app)  
     IPFS web app interface.
 
 * [starlog](https://github.com/ipfs/starlog)  
     Logging the development of an interplanetary filesystem. This will evenutlaly be a way of making blog posts with IPFS.
+
+* [station](https://github.com/ipfs/station)  
+    Electron Shell based IPFS app.
 
 * [webui](https://github.com/ipfs/webui)  
     The IPFS webui accessible from the api gateway typically at port 5001.

--- a/project-directory.md
+++ b/project-directory.md
@@ -41,7 +41,7 @@ These are all the repos found in the IPFS Github organization. If you still can'
 * [archives](https://github.com/ipfs/archives)  
     Repo to coordinate archival efforts with IPFS.
 
-* [apps](https://github.com/ipfs/apps)
+* [apps](https://github.com/ipfs/apps)  
     Coordinating writing apps on top of ipfs, and their concerns. 
 
 ### Specification Discussions
@@ -64,18 +64,18 @@ These are all the repos found in the IPFS Github organization. If you still can'
 
 ### In Development
 
-* [node-ipfs](https://github.com/ipfs/node-ipfs)  
+* [js-ipfs](https://github.com/ipfs/js-ipfs)  
     An IPFS implementation in Node.js.
 
 * [py-ipfs](https://github.com/ipfs/py-ipfs)  
-    python implementation of IPFS.
+    Python implementation of IPFS.
 
 * [go-ipld](https://github.com/ipfs/go-ipld)  
     This is the Go implementation of the IPLD spec.
 
 ### APIs
 
-* [node-ipfs-api](https://github.com/ipfs/node-ipfs-api)  
+* [js-ipfs-api](https://github.com/ipfs/js-ipfs-api)  
     A node client library for the IPFS API.
 
 * [go-ipfs-api](https://github.com/ipfs/go-ipfs-api)  
@@ -99,7 +99,7 @@ These are all the repos found in the IPFS Github organization. If you still can'
     The IPFS webui accessible from the api gateway typically at port 5001.
 
 * [starlog](https://github.com/ipfs/starlog)  
-    logging the development of an interplanetary filesystem. This will evenutlaly be a way of making blog posts with IPFS.
+    Logging the development of an interplanetary filesystem. This will evenutlaly be a way of making blog posts with IPFS.
 
 * [electron-app](https://github.com/ipfs/electron-app)  
     Electron Shell based IPFS app.
@@ -148,11 +148,11 @@ These are all the repos found in the IPFS Github organization. If you still can'
 * [dnslink-deploy](https://github.com/ipfs/dnslink-deploy)  
     Automatically set DNS records on Digital Ocean.
 
-* [node-ipfsd-ctl](https://github.com/ipfs/node-ipfsd-ctl)  
-    control an IPFS daemon (WIP).
+* [js-ipfsd-ctl](https://github.com/ipfs/js-ipfsd-ctl)  
+    Control an IPFS daemon (WIP).
 
 * [npm-go-ipfs](https://github.com/ipfs/npm-go-ipfs)  
-    install go-ipfs from npm.
+    Install go-ipfs from npm.
 
 * [fs-repo-migrations](https://github.com/ipfs/fs-repo-migrations)  
     These are migrations for the filesystem repository of IPFS clients.
@@ -167,13 +167,13 @@ These are all the repos found in the IPFS Github organization. If you still can'
     This repo will stress test IPFS filesystem capabilities.
 
 * [go-blocks](https://github.com/ipfs/go-blocks)  
-    go-blocks - IPFS blocks.
+    Go-blocks - IPFS blocks.
 
 * [go-iprs](https://github.com/ipfs/go-iprs)  
-    go-ipfs records.
+    Go-ipfs records.
 
 * [dir-index-html](https://github.com/ipfs/dir-index-html)  
-    directory listing html.
+    Directory listing html.
 
 * [ipfs-node-defaults](https://github.com/ipfs/ipfs-node-defaults)  
     Sane defaults for IPFS node configurations.
@@ -185,7 +185,7 @@ These are all the repos found in the IPFS Github organization. If you still can'
     Go commands. WIP.
 
 * [install-go-ipfs](https://github.com/ipfs/install-go-ipfs)  
-    install go-ipfs shell script.
+    Install go-ipfs shell script.
 
 * [go-log](https://github.com/ipfs/go-log)  
     A logging library used by go-ipfs.

--- a/project-directory.md
+++ b/project-directory.md
@@ -2,6 +2,8 @@ IPFS Project Directory
 ======================
 These are all the repos found in the IPFS Github organization. If you still can't find what you're looking for, try [searching Github]( https://github.com/search?utf8=%E2%9C%93&q=user%3Aipfs).
 
+Note: The repository descriptions (ought to) originate from the GitHub repository descriptions. Please make sure that those descriptions and these are synced.
+
 ## Table of Contents
 
 - [Top level updates](#top-level-updates)

--- a/project-directory.md
+++ b/project-directory.md
@@ -182,7 +182,7 @@ These are all the repos found in the IPFS Github organization. If you still can'
 * [install-go-ipfs](https://github.com/ipfs/install-go-ipfs)  
     Install go-ipfs shell script.
 
-* [ipfs-node-defaults](https://github.com/ipfs/ipfs-node-defaults)  
+* [ipfs-js-defaults](https://github.com/ipfs/ipfs-js-defaults)  
     Sane defaults for IPFS node configurations.
 
 * [js-ipfsd-ctl](https://github.com/ipfs/js-ipfsd-ctl)  

--- a/project-directory.md
+++ b/project-directory.md
@@ -230,5 +230,5 @@ These are all the repos found in the IPFS Github organization. If you still can'
     DMCA takedown notices
 
 * [refs-solarnet-storage](https://github.com/ipfs/refs-solarnet-storage)
-    Source for the `refs` tool. Content archived on the storage hosts.
+    Inventory of content archived on Solarnet storage hosts https://github.com/ipfs/archives
 


### PR DESCRIPTION
This is mostly following https://github.com/ipfs/js-ipfs/issues/32 by renaming and linking all changed repositories, but I also cleaned up the repo by alphabetizing everything and conforming to capitalizing the first letter of each description. 