### PR TITLE
Added a mini-project directory and link to FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The IPFS community has a lot of repositories:
 - [ipfs/faq](https://github.com/ipfs/faq) is for questions you might have about IPFS.
 - [ipfs/support](https://github.com/ipfs/support) is for issues with getting IPFS up and running.
 - [ipfs/community](https://github.com/ipfs/community) is for meta-questions on how we manage our community in general.
+- [project directory](https://github.com/ipfs/ipfs/blob/master/project-directory.md) is for all of our repositories.
 
 We also have these communication channels outside of GitHub:
 
@@ -37,7 +38,7 @@ We also have these communication channels outside of GitHub:
 - Google Group: [ipfs-users@groups.google.com](https://groups.google.com/forum/#!forum/ipfs-users) if you like email.
 - Twitter: [@IPFSbot](https://twitter.com/ipfsbot) for some news.
 
-Searching for something else? Need to submit an issue? Want to contribute? Take a peek at [project-directory.md](project-directory.md) which maps out all of the repositories for the IPFS project.
+Searching for something else? Need to submit an issue? Want to contribute? Take a peek at [project-directory.md](https://github.com/ipfs/ipfs/blob/master/project-directory.md) which maps out all of the repositories for the IPFS project.
 
 ## IPFS Talks
 
@@ -111,7 +112,7 @@ IPFS has a name service:
 
 ## FAQ
 
-Feel free to submit more questions as issues or via my email.
+Feel free to browse and submit more questions at the [ipfs/faq](https://github.com/ipfs/faq/issues) discussion repo.
 
 #### What is the goal of IPFS?
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,23 @@ If you find a vulnerability that may affect live deployments -- for example, by 
 If the issue is a protocol weakness that cannot be immediately exploited or something not yet deployed, just discuss it openly.
 
 ## [Project directory](project-directory.md)
-Lost? Searching for something? Need to submit an issue? Want to contribute? Take a peek at [project-directory.md](project-directory.md) which maps out all the repositories for the ipfs project on Github.
 
+The IPFS community has a lot of repositories:
+
+- [ipfs/ipfs](https://github.com/ipfs/ipfs) (this repo) is _the_ repo for our updates and news.
+- [ipfs/go-ipfs](https://github.com/ipfs/go-ipfs) is the main, reference implementation.
+- [ipfs/specs](https://github.com/ipfs/specs) contains the technical specs for IPFS.
+- [ipfs/faq](https://github.com/ipfs/faq) is for questions you might have about IPFS.
+- [ipfs/support](https://github.com/ipfs/support) is for issues with getting IPFS up and running.
+- [ipfs/community](https://github.com/ipfs/community) is for meta-questions on how we manage our community in general.
+
+We also have these communication channels outside of GitHub:
+
+- IRC: [#ipfs on chat.freenode.net](irc://chat.freenode.net/%23ipfs) for live help and some dev discussions ([Logs](https://botbot.me/freenode/ipfs/))
+- Google Group: [ipfs-users@groups.google.com](https://groups.google.com/forum/#!forum/ipfs-users) if you like email.
+- Twitter: [@IPFSbot](https://twitter.com/ipfsbot) for some news.
+
+Searching for something else? Need to submit an issue? Want to contribute? Take a peek at [project-directory.md](project-directory.md) which maps out all of the repositories for the IPFS project.
 
 ## IPFS Talks
 


### PR DESCRIPTION
This commit does two things: 
* It copies the small directory at ipfs.io/docs, which is helpful but not the only entry point to IPFS, so that people know what repos are good for questions. This should give a good overview of pertinent repos, as well as other communication channels.
* It points people to the ipfs/faq repository, so that people know that the FAQ here is not the only one. 

This PR is a result of discussions about better community building in https://github.com/ipfs/community/issues/69.