### PR TITLE
Added link for C++ client library

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ If you would you like to start your own language implementation of IPFS, check o
 | PHP | https://github.com/cloutier/php-ipfs-api | |
 | C# | https://github.com/TrekDev/net-ipfs-api | |
 | | https://github.com/richardschneider/net-ipfs-api | |
-| C/C++ | contact: [@PayasR](https://github.com/PayasR) | 0% |
+| C++ | https://github.com/vasild/cpp-ipfs-api | |
 | Julia | contact: [@rened](https://github.com/rened) | 0% |
 | Lua | contact: [@seclorum](https://github.com/seclorum) | 0% |
 | Erlang | ! | 0% |


### PR DESCRIPTION
Added the link for @vasild 's C++ API client library, https://github.com/vasild/cpp-ipfs-api