### PR TITLE
Rust API Client library change

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ If you would you like to start your own language implementation of IPFS, check o
 | Haskell     | https://github.com/davidar/hs-ipfs-api            | |
 | Swift       | https://github.com/ipfs/swift-ipfs-api            | |
 | CommonLisp  | https://github.com/WeMeetAgain/cl-ipfs-api        | |
-| Rust        | https://github.com/rmnoff/rust-ipfs-api<br>https://github.com/rschulman/rust-ipfs-api           | |
+| Rust        | https://github.com/rmnoff/rust-ipfs-api           | |
+|             | https://github.com/rschulman/rust-ipfs-api        | |
 | Ruby        | https://github.com/Fryie/ipfs-ruby                | |
 | Swift       | https://github.com/NeoTeo/ipfs-osx-service        | |
 | PHP         | https://github.com/cloutier/php-ipfs-api          | |

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ If you would you like to start your own language implementation of IPFS, check o
 | Haskell     | https://github.com/davidar/hs-ipfs-api            | |
 | Swift       | https://github.com/ipfs/swift-ipfs-api            | |
 | CommonLisp  | https://github.com/WeMeetAgain/cl-ipfs-api        | |
-| Rust        | https://github.com/rmnoff/rust-ipfs-api           | |
+| Rust        | https://github.com/rmnoff/rust-ipfs-api<br>https://github.com/rschulman/rust-ipfs-api           | |
 | Ruby        | https://github.com/Fryie/ipfs-ruby                | |
 | Swift       | https://github.com/NeoTeo/ipfs-osx-service        | |
 | PHP         | https://github.com/cloutier/php-ipfs-api          | |

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ If you would you like to start your own language implementation of IPFS, check o
 | Haskell     | https://github.com/davidar/hs-ipfs-api            | |
 | Swift       | https://github.com/ipfs/swift-ipfs-api            | |
 | CommonLisp  | https://github.com/WeMeetAgain/cl-ipfs-api        | |
-| Rust        | https://github.com/rschulman/rust-ipfs-api        | |
+| Rust        | https://github.com/rmnoff/rust-ipfs-api           | |
 | Ruby        | https://github.com/Fryie/ipfs-ruby                | |
 | Swift       | https://github.com/NeoTeo/ipfs-osx-service        | |
 | PHP         | https://github.com/cloutier/php-ipfs-api          | |


### PR DESCRIPTION
Hi! Guys it is the time to change rust library, because the one ipfs has right now is undone and wasn't updated since 2015.