### PR TITLE
Add another Rust API client library to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ If you would you like to start your own language implementation of IPFS, check o
 | Haskell     | https://github.com/davidar/hs-ipfs-api            | |
 | Swift       | https://github.com/ipfs/swift-ipfs-api            | |
 | CommonLisp  | https://github.com/WeMeetAgain/cl-ipfs-api        | |
-| Rust        | https://github.com/gkbrk/rust-ipfs-api            | |
+| Rust        | https://github.com/ferristseng/rust-ipfs-api      | |
+|             | https://github.com/gkbrk/rust-ipfs-api            | |
 |             | https://github.com/rmnoff/rust-ipfs-api           | |
 |             | https://github.com/rschulman/rust-ipfs-api        | |
 | Ruby        | https://github.com/Fryie/ipfs-ruby                | |


### PR DESCRIPTION
https://github.com/ferristseng/rust-ipfs-api is on crates.io and is well documented. Seems worth adding.