### PR TITLE
Proposal: Community Team Structure

### DIFF
--- a/TEAM_STRUCTURES.md
+++ b/TEAM_STRUCTURES.md
@@ -13,10 +13,6 @@
     - [IPFS Infrastructure](#ipfs-infrastructure)
     - [Dev Team Enablement (QA, Testing, Support)](#qa-testing-and-dev-team-enablement)
   - **[Community](#community):**
-    - Evangelism (Events, Social Media)
-    - Editorial (Blogs, Documentation)
-    - Education (ProtoSchool, Demos)
-    - Automation (Probots, etc)
   - **Ongoing Efforts to Support Specific Uses:**
     - [Integration with Web Browsers](#integration-with-web-browsers)
     - [Dynamic Data and Capabilities](#dynamic-data-and-capabilities)
@@ -63,10 +59,6 @@ A byproduct of both of these team structures achieves another important goal: ma
   - [IPFS Infrastructure](#ipfs-infrastructure)
   - [Dev Team Enablement (QA, Testing, Support)](#qa-testing-and-dev-team-enablement)
 - **[Community](#community):**
-  - Evangelism (Events, Social Media)
-  - Editorial (Blogs, Documentation)
-  - Education (ProtoSchool, Demos)
-  - Automation (Probots, etc)
 - **Ongoing Efforts to Support Specific Uses:**
   - [Integration with Web Browsers](#integration-with-web-browsers)
   - [Dynamic Data and Capabilities](#dynamic-data-and-capabilities)
@@ -137,7 +129,10 @@ The QA, Testing and Dev Team Enablement Working Group focuses on building develo
 
 ### Community
 
-> This Working Group hasn't been formed yet.
+- Evangelism (Events, Social Media)
+- Editorial (Blogs, Documentation)
+- Education (ProtoSchool, Demos)
+- Automation (Probots, etc)
 
 - **Coordination**: https://github.com/ipfs/community
 - **Captain**: [Mikeal Rogers](https://github.com/mikeal)


### PR DESCRIPTION
I'd like to propose a re-working of the team structure around community stuff.

First and foremost, I'm collapsing into a single group for now. As that group grows we can break out along the lines noted but for the time being it's easier to organize it as a single WG.

The idea here is that all of the activities we're partaking in where the primary goal is to grow a community come under one umbrella. For now, I removed the maintenance of the websites as it seemed like a bit much until we have a real editorial team with contributors. 

It's also worth noting that I think documentation, to some extent, needs to also live with project developers. The way things were worded before gave me the impression that project engineers weren't expected to document APIs they build or change and that it falls on this other group. That isn't very practical, initial docs for features should ship **with the feature**, with the long term improvement of those docs being a community endeavor.

The good news is that this structure gives it all a captain, me :)