### PR TITLE
Proposal: Add Decentralized Data Stewardship WG

### DIFF
--- a/TEAM_STRUCTURES.md
+++ b/TEAM_STRUCTURES.md
@@ -197,7 +197,7 @@ The IPFS Cluster Working Group is the team implementing IPFS Cluster.
 
 ### Decentralized Data Stewardship
 
-- **Coordination**: Soon(tm)
+- **Coordination**: https://github.com/ipfs/decentralized-data-stewardship
 - **Captain**: [Michelle Hertzfeld](https://github.com/meiqimichelle)
 
 User research, collaborations, and products that support holding data together on decentralized networks.

--- a/TEAM_STRUCTURES.md
+++ b/TEAM_STRUCTURES.md
@@ -17,6 +17,7 @@
     - [Integration with Web Browsers](#integration-with-web-browsers)
     - [Dynamic Data and Capabilities](#dynamic-data-and-capabilities)
     - [IPFS Cluster](#ipfs-cluster)
+    - [Decentralized Data Stewardship](#decentralized-data-stewardship)
 - [Existing **Research** Groups](#existing-research-groups)
 
 ## Description
@@ -193,6 +194,20 @@ The IPFS Cluster Working Group is the team implementing IPFS Cluster.
 
 - Design and implement IPFS Cluster.
 - Provide knowledge and APIs that organizations with large data sets can use.
+
+### Decentralized Data Stewardship
+
+- **Coordination**: Soon(tm)
+- **Captain**: [Michelle Hertzfeld](https://github.com/meiqimichelle)
+
+User research, collaborations, and products that support holding data together on decentralized networks.
+
+**Responsibilities include**:
+
+- Participate in groups such as [Data Together](https://datatogether.org/)
+- Conduct [user research around managing large volumes of data](https://github.com/ipfs/user-research/tree/master/large-volumes) on IPFS
+- Support collaborations between IPFS and community members who need to manage large volumes of data
+- Research and prototype policy layers for just and inclusive data stewardship on decentralized networks
 
 ## Existing Research Groups
 


### PR DESCRIPTION
This PR adds a new working group called Decentralized Data Stewardship. This will hold the work that @flyingzumwalt , @michellebrous and I are doing around supporting user research, collaborations, and products that deal with data management on the decentralized web. Some examples include: 

- Participating in groups such as [Data Together](https://datatogether.org/)
- Conducting [user research around managing large volumes of data](https://github.com/ipfs/user-research/tree/master/large-volumes) on IPFS
- Supporting collaborations between IPFS and community members who need to manage large volumes of data

I would be the Captain, with @flyingzumwalt advising as needed.

@diasdavid requested this PR several days ago, and I know @flyingzumwalt was intending on submitting it, but got pulled into other things. Please consider this a first draft that I'm sure @flyingzumwalt will have edits to, but at least this 'placeholder' is here for the Q4 OKR process.