### PR TITLE
Move the ipfs-cluster WG to one of the main Dev Projects

### DIFF
--- a/TEAM_STRUCTURES.md
+++ b/TEAM_STRUCTURES.md
@@ -10,13 +10,13 @@
     - [JavaScript Core Dev](#javascript-core-dev)
     - [Golang Core Dev](#golang-core-dev)
     - [IPFS GUI](#ipfs-gui)
+    - [IPFS Cluster](#ipfs-cluster)
     - [IPFS Infrastructure](#ipfs-infrastructure)
     - [Dev Team Enablement (QA, Testing, Support)](#qa-testing-and-dev-team-enablement)
   - [**Community**](#community)
   - **Ongoing Efforts to Support Specific Uses:**
     - [Integration with Web Browsers](#integration-with-web-browsers)
     - [Dynamic Data and Capabilities](#dynamic-data-and-capabilities)
-    - [IPFS Cluster](#ipfs-cluster)
 - [Existing **Research** Groups](#existing-research-groups)
 
 ## Description
@@ -96,6 +96,18 @@ Making IPFS GUIs simple, accessible, reusable, and beautiful.
 - IPFS must be usable and comprehensible for everyone.
 - Publish and promote this work. Make doing the right thing the easiest thing.
 - Demonstrate the nature of the system with effortless, coherent, and compelling interfaces.
+
+### IPFS Cluster
+
+- **Coordination**: https://github.com/ipfs/ipfs-cluster
+- **Captain**: [Hector Sanjuan](https://github.com/hsanjuan)
+
+The IPFS Cluster Working Group is the team implementing IPFS Cluster.
+
+**Responsibilities include**:
+
+- Design and implement IPFS Cluster.
+- Provide knowledge and APIs that organizations with large data sets can use.
 
 ### IPFS Infrastructure
 
@@ -181,18 +193,6 @@ Research and development of building blocks that enable collaborative applicatio
 - Research and implement CRDTs on top of IPFS, creating building blocks that can be used by other applications.
 - Research Cryptographic ACLs (Capabilities Systems) and create building blocks to implement them.
 - Apply this research and implementation to products like PeerPad, validating the solutions and defining new problems to be solved.
-
-### IPFS Cluster
-
-- **Coordination**: https://github.com/ipfs/ipfs-cluster
-- **Captain**: [Hector Sanjuan](https://github.com/hsanjuan)
-
-The IPFS Cluster Working Group is the team implementing IPFS Cluster.
-
-**Responsibilities include**:
-
-- Design and implement IPFS Cluster.
-- Provide knowledge and APIs that organizations with large data sets can use.
 
 ## Existing Research Groups
 


### PR DESCRIPTION
`ipfs-cluster` has been treated as a project whose purpose is to fulfill a use case in the decentralization space, normally described as Large Volumes or Decentralised Data. Even though that those are some of its usecases, the truth is that ipfs-cluster is a core piece of the IPFS necessary to have IPFS run in a multitude of scenarios and serving way more use cases (e.g. hosted IPFS instances, pinning services, multinode management and more).

This PR moves IPFS Cluster from the `Ongoing Efforts to Support Specific Uses` and puts it next to the implementations of IPFS, IPFS GUI and IPFS Infrastructure.

Related to this PR we have the proposal of a new WG, the Decentralised Data Stewardship WG #353 