### PR TITLE
(Copyedit) Removes 'ongoing'

### DIFF
--- a/TEAM_STRUCTURES.md
+++ b/TEAM_STRUCTURES.md
@@ -14,7 +14,7 @@
     - [IPFS Infrastructure](#ipfs-infrastructure)
     - [Dev Team Enablement (QA, Testing, Support)](#qa-testing-and-dev-team-enablement)
   - [**Community**](#community)
-  - **Ongoing Efforts to Support Specific Uses:**
+  - **Efforts to Support Specific Uses:**
     - [Integration with Web Browsers](#integration-with-web-browsers)
     - [Dynamic Data and Capabilities](#dynamic-data-and-capabilities)
     - [Decentralized Data Stewardship](#decentralized-data-stewardship)
@@ -60,7 +60,7 @@ A byproduct of both of these team structures achieves another important goal: ma
   - [IPFS Infrastructure](#ipfs-infrastructure)
   - [Dev Team Enablement (QA, Testing, Support)](#qa-testing-and-dev-team-enablement)
 - **[Community](#community):**
-- **Ongoing Efforts to Support Specific Uses:**
+- **Efforts to Support Specific Uses:**
   - [Integration with Web Browsers](#integration-with-web-browsers)
   - [Dynamic Data and Capabilities](#dynamic-data-and-capabilities)
   - [IPFS Cluster](#ipfs-cluster)


### PR DESCRIPTION
Renames a category of WGs from "Ongoing efforts to support specific uses" to "Efforts to support specific uses." All of our WGs are "ongoing," so there's no need to call out this category as especially ongoing.