### PR TITLE
Removed sentence on the IPFS implementation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ These are the current implementations of IPFS:
 | Python | https://github.com/ipfs-shipyard/py-ipfs | starting (inactive) |
 | C | https://github.com/Agorise/c-ipfs | starting (inactive) |
 
-If you would you like to start your own language implementation of IPFS, check out the [IPFS Implementation Guide](https://github.com/ipfs/specs/blob/master/overviews/implement-ipfs.md), and the [Specifications](https://github.com/ipfs/specs). The specs are still evolving, but the core formats are stable and can be built on. Make sure to post an issue if you would like to start an effort, as many people have expressed interest in contributing to new implementations.
+If you would you like to start your own language implementation of IPFS, check out the [Specifications](https://github.com/ipfs/specs). The specs are still evolving, but the core formats are stable and can be built on. Make sure to post an issue if you would like to start an effort, as many people have expressed interest in contributing to new implementations.
 
 ### HTTP client libraries
 


### PR DESCRIPTION
We previously had:

> If you would you like to start your own language implementation of IPFS, check out the IPFS Implementation Guide (link -https://github.com/ipfs/specs/blob/master/overviews/implement-ipfs.md)

But that link no longer exists since we removed the `overviews` folder in https://github.com/ipfs/specs/pull/243. I'm not sure if there's another doc we'd like to point people at, but removing this part of the sentence and just pointing people at the specs seems reasonable.

cc @hsanjuan @johnnymatthews 