### PR TITLE
docs: update license range

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2019 Juan Batiz-Benet
+Copyright (c) 2014-2023 Juan Batiz-Benet
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updates the MIT license year range to 2023.